### PR TITLE
Add publishing to GitHub Packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+﻿name: Publish NuGet Package to GitHub Packages
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install .NET Core
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: 5.0.x
+
+      - name: Pack nuget
+        run: dotnet pack --configuration Release
+
+      - name: Push Nuget to GitHub Packages
+        uses: tanaka-takayoshi/nuget-publish-to-github-packages-action@v2.1
+        with:
+          nupkg-path: './bin/Release/*.nupkg'
+          repo-owner: czarzy
+          gh-user: czarzy
+          token: ${{ secrets.GITHUB_TOKEN }}
+          skip-duplicate: true
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: Nuget Package
+          path: ./bin/Release

--- a/HangfireJobHandler.csproj
+++ b/HangfireJobHandler.csproj
@@ -7,6 +7,7 @@
     <Company>Czarzo</Company>
     <Description>Hangfire job handler to avoid duplicate jobs.</Description>
     <Copyright></Copyright>
+    <RepositoryUrl>https://github.com/czarzy/HangfireJobHandler</RepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Added publishing to GitHub Packages through GitHub Actions.
After every commit to master branch it will try to publish new package version to GitHub Packages. If there will be duplicate version then it will not publish it.
There is also option to download from GitHub Action run zip with nupkg file to add it locally.

To use this repo through nuget. Add nuget.config file in root of your project. Like this:
```xml
<?xml version="1.0" encoding="utf-8"?>
<configuration>
    <packageSources>
        <add key="github" value="https://nuget.pkg.github.com/czarzy/index.json" />
    </packageSources>
    <packageSourceCredentials>
        <github>
            <add key="Username" value="LOGIN_GITHUB" />
            <add key="ClearTextPassword" value="PERSONAL_ACCESS_TOKEN_GITHUB" />
        </github>
    </packageSourceCredentials>
</configuration>
```
Where LOGIN_GITHUB is your GitHub username. And PERSONAL_ACCESS_TOKEN_GITHUB is your Personal Access Token from https://github.com/settings/tokens/new?scopes=read:packages&description=GitHub%20Packages%20Nuget%20Source